### PR TITLE
Add 'armor' dcSlug to isStrike check

### DIFF
--- a/scripts/pf2e-modifiers-matter.js
+++ b/scripts/pf2e-modifiers-matter.js
@@ -323,7 +323,7 @@ const hook_preCreateChatMessage = async (chatMessage, data) => {
   const currentDegreeOfSuccess = calcDegreePlusRoll(deltaFromDc, dieRoll)
   // noinspection JSDeprecatedSymbols (String.strike is irrelevant, IntelliJ!)
   const dcSlug = chatMessage.flags.pf2e.context.dc.slug
-  const isStrike = dcSlug === 'ac'
+  const isStrike = dcSlug === 'ac' || dcSlug === 'armor'
   const isSpell = chatMessage.flags.pf2e.origin?.type === 'spell'
   const isFlanking = chatMessage.flags.pf2e.context.options.includes('self:flanking')
   const targetedTokenUuid = chatMessage.flags.pf2e.context.target?.token


### PR DESCRIPTION
Fixes #23 

According to [stwlam](https://github.com/foundryvtt/pf2e/pull/7198#discussion_r1161234176), using the 'armor' slug for attacks is conventional. So, in 4.12, when a few checks' target DC slugs were specified as 'armor' instead of 'ac', the isStrike check in Modifiers Matter broke, since it only looked for the 'ac' slug. This change allows for both slugs to be valid, as they should be functionally identical. If they are _not_ functionally identical, then this change should be looked at again to ensure it doesn't have any odd edge cases.